### PR TITLE
Removing CMAKE_DEBUG_POSTFIX for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -602,9 +602,6 @@ class pyside_build(_build):
             if self.build_type.lower() == 'debug':
                 cmake_cmd.append("-DPYTHON_DEBUG_LIBRARY=%s" % self.py_library)
 
-        if sys.platform == 'win32':
-            cmake_cmd.append("-DCMAKE_DEBUG_POSTFIX=_d")
-
         if extension.lower() == "shiboken2":
             cmake_cmd.append("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=yes")
             if sys.version_info[0] > 2:


### PR DESCRIPTION
1. This is wrong for Python >= 3
2. No needed, because PySide2 does it now on it's own.