### PR TITLE
Prefer qmake-qt5 over qmake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,9 +162,9 @@ OPTION_OSXARCH = option_value("osx-arch")
 OPTION_XVFB = has_option("use-xvfb")
 
 if OPTION_QMAKE is None:
-    OPTION_QMAKE = find_executable("qmake")
-if OPTION_QMAKE is None:
     OPTION_QMAKE = find_executable("qmake-qt5")
+if OPTION_QMAKE is None:
+    OPTION_QMAKE = find_executable("qmake")
 if OPTION_CMAKE is None:
     OPTION_CMAKE = find_executable("cmake")
 


### PR DESCRIPTION
I tried to build pyside using setup.py here on Ubuntu and I get the same problem like mentioned in #21.
The solution is to perfer qmake-qt5 over qmake. This shouldn't make any difference on OSX and Windows.

Fixes #21